### PR TITLE
Mission and User stats + fixed a few bugs

### DIFF
--- a/src/bot/bot.gateway.ts
+++ b/src/bot/bot.gateway.ts
@@ -174,6 +174,7 @@ export class BotGateway {
       return;
     }
 
+    /*
     if (interaction.channelId == process.env.DISCORD_BOT_AAR_CHANNEL) {
       if (interaction.isButton() && interaction.customId) {
         const uniqueName = interaction.customId;
@@ -285,6 +286,7 @@ export class BotGateway {
       }
 
     }
+    */
 
 
   }

--- a/src/missions/missions.controller.ts
+++ b/src/missions/missions.controller.ts
@@ -22,6 +22,8 @@ export class MissionsController {
 
   @Post('/new')
   async newMission(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     console.log(body);
     const newMissionEmbed = new EmbedBuilder()
 
@@ -59,10 +61,14 @@ export class MissionsController {
       embeds: [newMissionEmbed]
     });
     return;
+    */
+    return {};
   }
 
   @Post('/update')
   async update(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
 
     const discordClient = this.discordProvider.getClient();
     let missionAuthor = await discordClient.users.fetch(body.missionAuthor);
@@ -99,10 +105,14 @@ export class MissionsController {
     ) as TextChannel;
     await channel.send({ content: `${body.updateAuthor} updated a mission!`, embeds: [newMissionEmbed] });
     return;
+    */
+    return {};
   }
 
   @Post('/request_audit')
   async requestAudit(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const newMissionEmbed = new EmbedBuilder()
       .setColor('#22cf26')
       .setTitle(body.name)
@@ -120,9 +130,13 @@ export class MissionsController {
       embeds: [newMissionEmbed],
     });
     return;
+    */
+    return {};
   }
   @Post('/request_audit_cancel')
   async requestAuditCancel(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const newMissionEmbed = new EmbedBuilder()
       .setColor('#ff2020')
       .setTitle(body.name)
@@ -140,10 +154,14 @@ export class MissionsController {
       embeds: [newMissionEmbed],
     });
     return;
+    */
+    return {};
   }
 
   @Post('/audit_submited')
   async auditSubmited(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const discordClient = this.discordProvider.getClient();
     const channel: TextChannel = discordClient.channels.cache.get(
       process.env.DISCORD_BOT_CHANNEL,
@@ -194,10 +212,14 @@ export class MissionsController {
     }
 
     return;
+    */
+    return {};
   }
 
   @Post('/new_history')
   async new_Hhistory(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const discordClient = this.discordProvider.getClient();
     const channel: TextChannel | ForumChannel = discordClient.channels.cache.get(
       process.env.DISCORD_BOT_AAR_CHANNEL,
@@ -275,10 +297,14 @@ export class MissionsController {
       });
     }
     return {};
+    */
+    return {};
   }
 
   @Post('/first_vote')
   async firstVote(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const discordClient = this.discordProvider.getClient();
     const channel: TextChannel = discordClient.channels.cache.get(
       process.env.DISCORD_VOTING_CHANNEL,
@@ -308,10 +334,14 @@ export class MissionsController {
     });
 
     return;
+    */
+    return {};
   }
 
   @Post('/bugreport')
   async bugreport(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const embed = new EmbedBuilder()
       .setColor('#ff0000')
       .setTitle(`Mission: ${body.name}`)
@@ -336,10 +366,14 @@ export class MissionsController {
       embeds: [embed],
     });
     return;
+    */
+    return {};
   }
 
   @Post('/review')
   async review(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const embed = new EmbedBuilder()
       .setColor('#ff0000')
       .setTitle(`Mission: ${body.name}`)
@@ -360,10 +394,14 @@ export class MissionsController {
       embeds: [embed],
     });
     return;
+    */
+    return {};
   }
 
   @Post('/aar')
   async aar(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const embed = new EmbedBuilder()
       .setColor('#ff0000')
       .setTitle(`Mission: ${body.name}`)
@@ -381,10 +419,14 @@ export class MissionsController {
       embeds: [embed],
     });
     return;
+    */
+    return {};
   }
 
   @Post('/media_posted')
   async mediaPosted(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     console.log('POSTING MEDIA');
     const embed = new EmbedBuilder()
       .setColor('#0000FF')
@@ -415,10 +457,14 @@ export class MissionsController {
     }
 
     return;
+    */
+    return {};
   }
 
   @Post('/youtube_video_uploaded')
   async youtubeVideoUploaded(@Body() body): Promise<object> {
+    /* Legacy Discord notification disabled
+
     const discordClient = this.discordProvider.getClient();
     const channel: TextChannel = discordClient.channels.cache.get(
       process.env.PR_VIDEO_VERIFICATION_CHANNEL_ID,
@@ -429,5 +475,7 @@ export class MissionsController {
     });
 
     return;
+    */
+    return {};
   }
 }

--- a/src/missions/missions.controller.ts
+++ b/src/missions/missions.controller.ts
@@ -237,23 +237,24 @@ export class MissionsController {
       gameplayHistoryEmbed.addFields({ name: 'AAR Replay:', value: body.aarReplayLink });
     }
     gameplayHistoryEmbed.addFields({ name: leaderText, value: leadersFieldText });
-    const discordButton = new ButtonBuilder()
-      .setLabel('Rate this mission')
-      .setCustomId(body.uniqueName)
-      .setStyle(ButtonStyle.Primary);
 
-    const row = new ActionRowBuilder<ButtonBuilder>({ components: [discordButton] })
+    const componentsToAttach = [];
+    if (body.outcome && typeof body.outcome === 'string' && body.outcome.trim() !== '') {
+      const discordButton = new ButtonBuilder()
+        .setLabel('Rate this mission')
+        .setCustomId(body.uniqueName)
+        .setStyle(ButtonStyle.Primary);
+
+      const row = new ActionRowBuilder<ButtonBuilder>({ components: [discordButton] });
+      componentsToAttach.push(row);
+    }
 
     if (body.discordThreadId) {
-      const thread = await discordClient.channels.fetch(body.discordThreadId).catch(() => null);
-      if (thread && thread.isThread()) {
-        await thread.send({
-          content: sendText,
-          embeds: [gameplayHistoryEmbed],
-          components: [row],
-        });
-        return {};
-      }
+      // For missions using the new live-session system (Reforger), the outcome notification
+      // is handled by the server.controller's edit-discord-message endpoint which
+      // deletes the old 'loading' message and posts a fresh one to trigger a notification.
+      // We skip the legacy 'New mission history recorded!' message here to avoid double-posting.
+      return {};
     }
 
     if (channel.type === ChannelType.GuildForum) {
@@ -263,14 +264,14 @@ export class MissionsController {
         message: {
           content: sendText,
           embeds: [gameplayHistoryEmbed],
-          components: [row],
+          components: componentsToAttach,
         }
       });
     } else {
       await channel.send({
         content: sendText,
         embeds: [gameplayHistoryEmbed],
-        components: [row],
+        components: componentsToAttach,
       });
     }
     return {};

--- a/src/server/server.controller.ts
+++ b/src/server/server.controller.ts
@@ -102,8 +102,6 @@ export class ServerController {
 
         if (channel.type === ChannelType.GuildForum) {
             // ── Forum channel: each session is a forum post ──
-            // Only reuse a post if we have an explicit threadId from activeSession.
-            // No name-based fallback — if activeSession was cleared, always start fresh.
             const forum = channel as ForumChannel;
 
             if (body.threadId) {
@@ -114,6 +112,15 @@ export class ServerController {
                 });
                 thread = fetched as ThreadChannel;
                 console.log(`[post-discord-message] Found by ID: ${!!thread}`);
+            }
+
+            // Name-based fallback if not found by ID or ID was missing
+            if (!thread && body.threadName) {
+                console.log(`[post-discord-message] Searching for forum post by name "${body.threadName}"`);
+                const activeThreads = await forum.threads.fetchActive();
+                const found = activeThreads.threads.find((t) => t.name === body.threadName);
+                thread = found as ThreadChannel ?? null;
+                if (thread) console.log(`[post-discord-message] Found existing forum post by name: ${thread.id}`);
             }
 
             if (!thread) {

--- a/src/sessions/session.service.ts
+++ b/src/sessions/session.service.ts
@@ -63,12 +63,38 @@ export class SessionService implements OnModuleInit {
 
   private async closeOrphanedSessions(): Promise<void> {
     try {
-      const result = await this.db.collection('server_sessions').updateMany(
+      // Close real sessions with their last snapshot time (or now if none)
+      const realResult = await this.db.collection('server_sessions').updateMany(
         { endedAt: null, isPlaceholder: { $ne: true } },
-        { $set: { endedAt: new Date(), endReason: 'stale' } },
+        [
+          {
+            $set: {
+              endedAt: {
+                $ifNull: [{ $arrayElemAt: ['$snapshots.time', -1] }, new Date()],
+              },
+              endReason: 'stale',
+            },
+          },
+        ],
       );
-      if (result.modifiedCount > 0) {
-        this.logger.log(`closed ${result.modifiedCount} orphaned session(s) from previous run`);
+      // Close placeholders with their startedAt (0 duration)
+      const placeholderResult = await this.db.collection('server_sessions').updateMany(
+        { endedAt: null, isPlaceholder: true },
+        [
+          {
+            $set: {
+              endedAt: '$startedAt',
+              endReason: 'stale',
+            },
+          },
+        ],
+      );
+
+      const totalClosed = realResult.modifiedCount + placeholderResult.modifiedCount;
+      if (totalClosed > 0) {
+        this.logger.log(
+          `closed ${totalClosed} orphaned session(s) from previous run (${realResult.modifiedCount} real, ${placeholderResult.modifiedCount} placeholders)`,
+        );
       }
     } catch (err) {
       this.logger.error('failed to close orphaned sessions', err);
@@ -109,7 +135,7 @@ export class SessionService implements OnModuleInit {
       if (ageSeconds > STALE_THRESHOLD_SECONDS) {
         this.logger.warn(`stats are stale (${Math.round(ageSeconds)}s old)`);
         if (this.activeSessionId) {
-          await this.closeSession('stale');
+          await this.closeSession('stale', new Date(stats.updated * 1000));
         }
         this.updateBaseline(stats);
         return;
@@ -192,13 +218,21 @@ export class SessionService implements OnModuleInit {
     }
   }
 
-  private async closeSession(reason: string): Promise<void> {
+  private async closeSession(reason: string, endTime?: Date): Promise<void> {
     if (!this.activeSessionId) return;
+
+    // Use provided endTime (e.g. from stale stats), or lastKnown activity, or current time
+    const endedAt =
+      endTime ??
+      (this.lastUpdated > 0 ? new Date(this.lastUpdated * 1000) : new Date());
+
     await this.db.collection('server_sessions').updateOne(
       { _id: this.activeSessionId },
-      { $set: { endedAt: new Date(), endReason: reason } },
+      { $set: { endedAt, endReason: reason } },
     );
-    this.logger.log(`closed session ${this.activeSessionId} (reason: ${reason})`);
+    this.logger.log(
+      `closed session ${this.activeSessionId} (reason: ${reason}, endedAt: ${endedAt.toISOString()})`,
+    );
     this.activeSessionId = null;
   }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 import { DiscordClientProvider } from '@discord-nestjs/core';
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { Routes } from 'discord.js';
 
 @Controller('users')
@@ -57,6 +57,30 @@ export class UsersController {
     );
 
     return donatorRole.members;
+  }
+
+  @Get('/role-members')
+  async findRoleMembers(@Query('roleId') roleId: string): Promise<object> {
+    const client = this.discordProvider.getClient();
+    const guildId = process.env.DISCORD_SERVER_ID;
+    const gcGuild = client.guilds.cache.get(guildId);
+
+    const targetRoleId =
+      roleId || process.env.DISCORD_MEMBER_ROLE_ID;
+
+    await gcGuild.roles.fetch();
+    await gcGuild.members.fetch();
+
+    const role = gcGuild.roles.cache.get(targetRoleId);
+    if (!role) {
+      return { ok: false, error: 'Role not found' };
+    }
+
+    return {
+      ok: true,
+      roleId: targetRoleId,
+      memberIds: role.members.map((m) => m.id),
+    };
   }
 
   @Get('/:id')


### PR DESCRIPTION
Merge with https://github.com/Global-Conflicts-ArmA/global-conflicts-website/pull/32

## Update `discord-bot/.env`
A new variable is required for the bot to fetch member lists for the website's activity reporting. Please add the following:
```env
# The ID of the primary community member role (e.g., 'Regular Member')
DISCORD_MEMBER_ROLE_ID=746545788930359358
```

## Key Changes

### Global Conflicts Website
*   **Enhanced Stats Dashboard:**
    *   **Comprehensive Session Aggregation:** New bar chart mapping Peak, Average, and Unique players per session. Supports custom date ranges and defaults to the last 6 months.
    *   **Advanced Player Count Chart:** Dual-mode filtering. Switch between a fixed "Week Selector" (Monday-to-Monday window) or a "Custom Range" with manual date/time pickers.
    *   **Visual Pruning:** Line charts now "jump" over zero-player periods, removing flat-line clutter and highlighting actual play sessions.
*   **Mission Analytics:**
    *   **Player Activity Dashboard:** New `userstats` page that tracks participation based on Discord role membership.
    *   **Duration Metrics:** Added Min, Median, and Max duration columns to the mission list, calculated from historical session data.
*   **Admin Tools:**
    *   **Database Utility:** Added developer-only Export and Import functionality for easier local environment syncing.
    *   **Auto-Correction:** Implemented automated slug repair and visibility logic for missions during GitHub synchronization.

### Discord Bot
*   **Session Reliability:**
    *   **Precision Timing:** Refined duration calculation logic to eliminate inflation and prevent "zombie" session placeholders from lingering.
    *   **Thread Management:** Fixed a bug causing duplicate forum threads to be spawned for the same active session.
*   **Legacy Cleanup:**
    *   Disabled old Discord notification flows to prepare for the unified Reforger-centric notification system.
    *   Suppressed redundant AAR notifications for Reforger-specific sessions.
*   **Integration:**
    *   Exposed a new `/users/role-members` endpoint to feed the website's player activity reports.