### PR TITLE
fix(bot): Server-viewer & bot activity

### DIFF
--- a/src/bot/bot.gateway.ts
+++ b/src/bot/bot.gateway.ts
@@ -23,7 +23,7 @@ export class BotGateway {
     @InjectDb() private readonly db: mongo.Db,
   ) { }
 
-  @Once('ready')
+  @Once('clientReady')
   onReady(): void {
     this.logger.log(
       `Logged in as ${this.discordProvider.getClient().user.tag}!`,

--- a/src/swear-jar/swear-jar.service.ts
+++ b/src/swear-jar/swear-jar.service.ts
@@ -18,7 +18,7 @@ export class SwearJarService implements OnModuleInit {
     await this.loadSwearJarData();
   }
 
-  @Once('ready')
+  @Once('clientReady')
   onReady() {
     console.log('Swear Jar service is ready!');
   }


### PR DESCRIPTION
discord.js 14.27 renamed the ready event to clientReady; the Events enum no longer includes 'ready', so @discord-nestjs/core's IsBaseEvent() guard rejects it and @Once('ready') silently never registers a listener. This broke BotGateway's server-viewer polling/presence updates and SwearJarService's ready hook since the discord.js update landed.